### PR TITLE
Add logging functions and limited function tracing

### DIFF
--- a/bash-4.3.30/burp.c
+++ b/bash-4.3.30/burp.c
@@ -24,6 +24,15 @@
 
 #include "burp.h"
 
+#define MAX_CALL_DEPTH 64
+#define FULL_INDENT 4
+#define SMALL_INDENT 2
+
+int g_log_indent=-FULL_INDENT;
+char **g_function_stack;
+char **g_current_function;
+FILE *g_log_stream;
+
 int g_translate_html = 0;
 
 void
@@ -261,4 +270,112 @@ burps_html(burpT *burpP, const char *stringP)
 	burps(burpP, stringP);
 	g_translate_html = save;
 }
+
+
+void log_init()
+{
+	g_log_stream = stdout;
+	g_function_stack = (char **) malloc(MAX_CALL_DEPTH * sizeof(char **));
+	memset(g_function_stack, 0, MAX_CALL_DEPTH * sizeof(g_function_stack[0]));
+	g_current_function = g_function_stack-1;
+}
+
+void log_close()
+{
+	while (g_current_function >= g_function_stack)
+		free(*g_current_function);
+	free(g_function_stack);
+}
+
+// log_enter(): When invoking this function, be sure to invoke log_return() at all possible
+// return points in order to keep the logging consistent and avoid memory bugs.
+void log_enter(char *format, ...)
+{
+	va_list args;
+	char *pNameEnd;
+	char full_format[256];
+	int i;
+
+	if (!g_log_stream)
+		return;
+
+	g_log_indent += FULL_INDENT;	// persistent full indent
+	sprintf(full_format, "%-*.0dEnter %s", g_log_indent, 0, format);
+	if (full_format[strlen(full_format)-1] != '\n')
+		strcat(full_format, "\n");
+	for (i=FULL_INDENT-1; i<g_log_indent; i+=FULL_INDENT)
+		full_format[i]='|';
+	if (i>=FULL_INDENT) full_format[i-FULL_INDENT]='.';
+
+	if (!(pNameEnd = strchr(format, '(')))
+	{
+		fprintf(stderr, "Error in call to log_enter(): Required format is funcname(args)\n");
+		return;
+	}
+	else
+	{
+		int length = (int)(pNameEnd-format);
+		g_current_function++;
+		*g_current_function = (char *) malloc((length+1)*sizeof(char));
+		strncpy(*g_current_function, format, length);
+		(*g_current_function)[length]='\0';
+	}
+
+	va_start(args, full_format);
+	vfprintf(g_log_stream, full_format, args);
+	va_end(args);
+}
+
+void log_info(char *format, ...)
+{
+	va_list args;
+	char full_format[256];
+	int i;
+
+	if (!g_log_stream)
+		return;
+
+	g_log_indent += SMALL_INDENT;	// temporary small indent
+	sprintf(full_format, "%-*.0d%s(): %s", g_log_indent, 0, *g_current_function, format);
+	if (full_format[strlen(full_format)-1] != '\n')
+		strcat(full_format, "\n");
+	for (i=FULL_INDENT-1; i<g_log_indent; i+=FULL_INDENT)
+		full_format[i]='|';
+	g_log_indent -= SMALL_INDENT;
+
+	va_start(args, full_format);
+	vfprintf(g_log_stream, full_format, args);
+	va_end(args);
+}
+
+// log_return: Simple logging and bookkeeping for function returns
+void log_return()
+{
+    log_return_msg(NULL);
+}
+
+// A variation of log_return() that allows an arbitrary message upon function return
+void log_return_msg(char *msg)
+{
+	char full_entry[256];
+	char entry_format[]="%-*.0dLeave %s() - %s\n";
+	int i;
+
+	if (!g_log_stream)
+		return;
+
+	// Construct the log entry, silently ignoring the msg if it is NULL.
+	if (!msg)
+		strcpy(entry_format+16, "\n");
+	sprintf(full_entry, entry_format, g_log_indent, 0, *g_current_function, msg);
+	for (i=FULL_INDENT-1; i<g_log_indent; i+=FULL_INDENT)
+		full_entry[i]='|';
+	if (i>=FULL_INDENT) full_entry[i-FULL_INDENT]='`';
+	fprintf(g_log_stream, full_entry);
+	free(*g_current_function);
+	g_current_function--;
+	g_log_indent -= FULL_INDENT;
+}
+
+
 #endif

--- a/bash-4.3.30/burp.h
+++ b/bash-4.3.30/burp.h
@@ -21,3 +21,10 @@ void burp_rtrim(burpT *burpP);
 
 #define INDENT(X) X.m_indent++
 #define OUTDENT(X) { assert(0 < X.m_indent); X.m_indent--; }
+
+void log_init();
+void log_close();
+void log_enter(char *format, ...);
+void log_info(char *format, ...);
+void log_return();
+void log_return_msg(char *msg);


### PR DESCRIPTION
Existing loggers for C programs are not ideal for our needs. So we are adding a simple, roll-your-own logger. The implementation has been added to `burp.c`.

How to use: 
1. Bookend program execution with `log_init()` and `log_close()`.
2. Bookend calls and returns with `log_enter()` and `log_return()` or `log_return_msg()`. Be very careful not to miss any return paths because the logger cannot tell when the "enters" and "returns" are out of sync.

We plan to add invocations of `log_info()` for finer-grained logging as needed.
Later, we might make the logging more flexible, including the option to dynamically turn it on/off anywhere in the code to help with debugging. 