### PR TITLE
Serialize the printing of function definitions

### DIFF
--- a/bash-4.3.30/burp.h
+++ b/bash-4.3.30/burp.h
@@ -1,3 +1,7 @@
+#ifndef TRUE
+#  define TRUE 1
+#  define FALSE 0
+#endif
 
 typedef struct {
 	char	*m_P;
@@ -24,7 +28,9 @@ void burp_rtrim(burpT *burpP);
 
 void log_init();
 void log_close();
+void log_activate();
+void log_deactivate();
 void log_enter(char *format, ...);
 void log_info(char *format, ...);
 void log_return();
-void log_return_msg(char *msg);
+void log_return_msg(char *msg_template, ...);

--- a/bash-4.3.30/burp.h
+++ b/bash-4.3.30/burp.h
@@ -21,3 +21,10 @@ void burp_rtrim(burpT *burpP);
 
 #define INDENT(X) X.m_indent++
 #define OUTDENT(X) { assert(0 < X.m_indent); X.m_indent--; }
+
+void log_init();
+void log_close();
+void log_enter(char *format, ...);
+void log_info(char *format, ...);
+void log_return();
+void log_return_msg(char *msg);

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -19,7 +19,7 @@ static burpT g_new = {0,0,0,0,0,0};
 static burpT g_braced = {0,0,0,0,0,0};
 
 int g_regmatch_special_case = FALSE;
-int	g_function_nesting_level = 0;
+int	g_is_inside_function = FALSE;
 int g_function_parms  = 0;
 
 int g_rc_identifier   = 0;
@@ -599,7 +599,7 @@ emitSimpleVariable(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 	case '7':
 	case '8':
 	case '9':
-		if (g_function_nesting_level > 0) {
+		if (g_is_inside_function) {
 			int 	parameter;
 
 			parameter = c - '0';

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -1773,6 +1773,7 @@ fixBracedString(const char *startP, fix_typeE want, fix_typeE *gotP)
 	char	*resultP;
 
 	log_enter("fixBracedString (startP=%s, want=%d)", startP, want);
+log_deactivate();
 
 	if (want == FIX_EXPRESSION) {
 		goto dont_fire;
@@ -1866,6 +1867,7 @@ fire:
 		}
 		xfree(arrayPP);
 		if (resultP) {
+log_activate();
 		    log_return_msg("\'fire\' section");
 			return resultP;
 	}	}
@@ -1875,6 +1877,7 @@ dont_fire:
 	string_to_buffer(startP);
 	resultP = fix_string1(want, gotP);
 
+log_activate();
 	log_return_msg("\'dont fire\' section");
 	return resultP;
 }

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -463,8 +463,7 @@ replaceSingleQuotes(void)
 			break;
 		case '\n':
 			if (in_quotes == '\'') {
-				burpc(&g_new, '\\');
-				burpc(&g_new, 'n');
+				burp(&g_new, "\\n");
 				continue;
 			}
 			break;
@@ -609,9 +608,7 @@ emitSimpleVariable(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 			}
 		} else {
 			g_translate.m_uses.m_sys = 1;
-			burps(&g_new, "sys.argv[");
-			burpc(&g_new, c);
-			burps(&g_new, "]");
+			burp(&g_new, "sys.argv[%c]", c);
 		}
 		got = FIX_VAR;
 		break;
@@ -718,8 +715,7 @@ emitFunction(char *nameP, char *parm1P, char *parm2P, int indirect, int under_qu
 	log_enter("emitFunction (nameP=%s, parm1P=%s, parm2P=%s, indirect=%d, under_quotes=%d)",
 			nameP, parm1P, parm2P, indirect, under_quotes);
 
-	burps(&g_new, nameP);
-	burpc(&g_new, '(');
+	burp(&g_new, "%s(", nameP);
 	if (indirect) {
 		g_translate.m_function.m_get_value = 1;
 		burp(&g_new, "GetValue(%s.val)", parm1P);

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -354,7 +354,7 @@ replaceSingleQuotes(void)
 				if (!in_quotes) {
 					in_quotes = '$';
 					++P;
-                    c         = '"';
+					c         = '"';
 					break;
 			}	}
 			if (P[1] == '"') {
@@ -507,7 +507,8 @@ emitQuotedString(char *startP)
 {
 	char *P;
 	int	 c;
-	
+
+	log_enter("emitQuotedString (startP=%s)", startP);
 	burpc(&g_new, '"');
 	for (P = startP; ; ++P) {
 		c = *P;
@@ -528,7 +529,9 @@ emitQuotedString(char *startP)
 			burpc(&g_new, '\\');
 		}
 		burpc(&g_new, c);
-}	}
+	}
+	log_return();
+}
 
 static char *emitSpecial1(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP);
 
@@ -626,8 +629,8 @@ emitSimpleVariable(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 		    burps(&g_new, "match_object.group");
 			P += len-1;
 			c = *P;
-        }
-        else {
+		}
+		else {
 			burpc(&g_new, c);
 			for (; (c = *P) && (c == '_' || isalnum(c)); ++P) {
 				burpc(&g_new, c);
@@ -635,11 +638,9 @@ emitSimpleVariable(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 			if (!g_underDollarExpression) {
 				burps(&g_new, ".val");
 			}
-        }
+		}
 		got = FIX_VAR;
 #ifndef TEST
-		*P = 0;
-        seen_global(startP, 0);
 		*P = c;
 #endif
 	}
@@ -654,6 +655,8 @@ emitString(char *startP, const char *terminatorsP, int under_quotes)
 	int			c, offset, in_quotes;
 	fix_typeE	got;
 
+	log_enter("emitString (startP=%s, terminatorsP=%s, under_quotes=%d)",
+			  startP, terminatorsP, under_quotes);
 	in_quotes = 0;
 	for (P = startP; ; ++P) {
 		c = *P;
@@ -702,6 +705,7 @@ done:
 	if (in_quotes) {
 		burpc(&g_new, '"');
 	}
+	log_return();
 	return P;
 }
 
@@ -730,9 +734,14 @@ emitFunction(char *nameP, char *parm1P, char *parm2P, int indirect, int under_qu
 			g_new.m_lth = offset;
 	}	}
 	burpc(&g_new, ')');
+
+	log_return();
 	return endP;
 }
 
+// Process variable names following $ or ${. Handles variables having the indirection 
+// prefix "!" and/or a postfix in the set { [*] [@] :- := :+ :? } while handing off 
+// simpler variable name instances to emitSimpleVariable, then finally some postprocessing.
 static char *
 emitVariable(char *startP, int braced, int in_quotes, fix_typeE want, fix_typeE *gotP)
 {
@@ -740,6 +749,8 @@ emitVariable(char *startP, int braced, int in_quotes, fix_typeE want, fix_typeE 
 	int			c, array, indirect;
 	fix_typeE	got;
 
+	log_enter("emitVariable (startP=%s, braced=%d, in_quotes=%d, want=%d)",
+			startP, braced, in_quotes, want);
 	start2P     = 0;
 	functionP   = 0;
 
@@ -756,6 +767,7 @@ emitVariable(char *startP, int braced, int in_quotes, fix_typeE want, fix_typeE 
 			end_start1P = start2P;
 			switch(c = *start2P) {
 			case 0:
+				log_return_msg("Early return, null character");
 				return 0;
 			case '*':
 				if (indirect == 1 && start2P[1] == '}') { 	// ${!prefix*}
@@ -848,6 +860,7 @@ emitVariable(char *startP, int braced, int in_quotes, fix_typeE want, fix_typeE 
 				endP = emitFunction(functionP, startP, start2P, indirect, in_quotes);
 				*end_start1P = c;
 				if (!endP) {
+					log_return_msg("Early return, null character");
 					return 0;
 				}
 				goto done;
@@ -856,7 +869,7 @@ emitVariable(char *startP, int braced, int in_quotes, fix_typeE want, fix_typeE 
 	}	}
 	endP = emitSimpleVariable(startP, in_quotes, want, gotP);
 done:
-    if (braced) {
+	if (braced) {
 		int offset;
 
 		array = (*endP == '[' || g_regmatch_special_case);
@@ -879,6 +892,7 @@ done:
 			g_new.m_lth = offset;
 			switch (c) {
 			case 0:
+				log_return_msg("Early return, null character");
 				return 0;
 			case '}':
 				++endP;
@@ -895,6 +909,7 @@ done:
 			burpc(&g_new, c);
 	}	}
 finish:
+	log_return();
 	return endP;
 }
 
@@ -906,6 +921,8 @@ emitDollarExpression(char *startP, int in_quotes, fix_typeE want, fix_typeE *got
 	char 		*P, *P1, *endP;
 	int  		start, offset, blank, c, brackets;
 	fix_typeE	got;
+
+	log_enter("emitDollarExpression (startP=%s, in_quotes=%d, want=%d)", startP, in_quotes, want);
 
 	++g_underDollarExpression;
 	*gotP    = FIX_INT;
@@ -972,6 +989,7 @@ done:
 		if (g_underDollarExpression == 1) {
 			// Do allow array
 			if (!translate_expression(g_new.m_P + start, &P1, 1)) {
+				log_return_msg("Early exit after translation");
 				return 0;
 			}
 			g_new.m_lth = start;
@@ -980,6 +998,7 @@ done:
 #endif
 	}
 	--g_underDollarExpression;
+	log_return();
 	return P;
 } 
 
@@ -1062,14 +1081,17 @@ done:
 	return P;
 }
 
-// Returns 0 if not special
-
+// Identifies tilde, backtick, subshell and double-paren expressions as well as 
+// variable names following $ or ${, dispatches each to their appropriate handler,
+// and attempts a type-fixing of the result
 static char *
 emitSpecial1(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 {
 	char *endP, *P;
 	int	 c, c1, start;
 	
+	log_enter("emitSpecial1 (startP=%s, in_quotes=%d, want=%d)", startP, in_quotes, want);
+
 	endP   = 0;
 	start  = g_new.m_lth;
 
@@ -1121,6 +1143,7 @@ emitSpecial1(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 			case FIX_INT:
 			case FIX_VAR:
 			case FIX_ARRAY:
+				log_info("Casting %s to string", start);
 				P = burp_extend(&g_new, start, 4);
 				memcpy(P, "str(", 4);
 				if (got == FIX_ARRAY) {
@@ -1134,6 +1157,7 @@ emitSpecial1(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 			break;
 		case FIX_ARRAY:
 			if (got != FIX_ARRAY) {
+				log_info("Casting %s to array", start);
 				P = burp_extend(&g_new, start, 6);	
 				g_translate.m_function.m_array = 1;
 				memcpy(P, "Array(", 6);
@@ -1144,6 +1168,8 @@ emitSpecial1(char *startP, int in_quotes, fix_typeE want, fix_typeE *gotP)
 		}
 		*gotP = got;
 	}
+
+	log_return();
 	return endP;
 }
 
@@ -1166,6 +1192,9 @@ static fix_typeE
 combine_types(int offset, fix_typeE want_type, fix_typeE was_type, fix_typeE new_type)
 {
 	char	*P;
+
+	log_enter("combine_types (offset=%d, want=%d, was=%d, new=%d)",
+				offset, want_type, was_type, new_type);
 
 	switch (want_type) {
 	case FIX_ARRAY:
@@ -1213,6 +1242,7 @@ combine_types(int offset, fix_typeE want_type, fix_typeE was_type, fix_typeE new
 
 	if (was_type == FIX_NONE) {
 		// Do nothing more
+		log_return_msg("Simple cast");
 		return new_type;
 	}
 	if (was_type == new_type) {
@@ -1222,6 +1252,7 @@ combine_types(int offset, fix_typeE want_type, fix_typeE was_type, fix_typeE new
 			// Join two things together
 			P = burp_extend(&g_new, offset, 1);
 			*P ='+';
+			log_return_msg("Concatenated");
 			return new_type;
 	}	}
 
@@ -1248,6 +1279,7 @@ combine_types(int offset, fix_typeE want_type, fix_typeE was_type, fix_typeE new
 			*P = 'S';
 			g_translate.m_function.m_str = 1;
 	}	}
+	log_return_msg("Cast to strings and concatenated");
 	return FIX_STRING;
 }
 
@@ -1270,6 +1302,7 @@ substitute(fix_typeE want)
 	char		**arrayPP, *P, *P1, *P2;
 	int			fileExpansion;
 
+	log_enter("substitute (want=%d)", want);
 	/* Return an array of strings; the brace expansion of TEXT.
 	 * Documentation says this is done before anything else
 	 */
@@ -1408,7 +1441,8 @@ done:
 		}
 		break;
 	}
-		
+
+	log_return();
 	return got;
 }
 
@@ -1612,8 +1646,8 @@ unmarkQuotes(int delete_quotes)
 		}
 		*P1++ = c;
 	}	
-    *P1 = 0;
-    g_buffer.m_lth = P1 - g_buffer.m_P;
+	*P1 = 0;
+	g_buffer.m_lth = P1 - g_buffer.m_P;
 }
 
 static void
@@ -1630,8 +1664,8 @@ unmarkExpand(void)
 		}
 		*P1++ = c;
 	}	
-    *P1 = 0;
-    g_buffer.m_lth = P1 - g_buffer.m_P;
+	*P1 = 0;
+	g_buffer.m_lth = P1 - g_buffer.m_P;
 }
 
 static void
@@ -1656,7 +1690,7 @@ unescapeDollar(void)
 /* Transforms g_buffer
  * Separator can be:
 	 + indicating concatonate parts (normal behaviour)
-     " indicating we are embedding the contents of this string inside popen
+	 " indicating we are embedding the contents of this string inside popen
  */
 
 static char *
@@ -1665,8 +1699,10 @@ fix_string1(fix_typeE want, fix_typeE *gotP)
 	fix_typeE	got;
 	int			is_expression;
 
+	log_enter("fix_string1 (want=%d)", want);
+
 	got = FIX_NONE;
-    if (!g_buffer.m_lth) {
+	if (!g_buffer.m_lth) {
 		goto done;
 	}
 		
@@ -1678,7 +1714,7 @@ fix_string1(fix_typeE want, fix_typeE *gotP)
 
 	if (want != FIX_EXPRESSION) {
 		is_expression           = 0;
-    	g_underDollarExpression = 0;
+		g_underDollarExpression = 0;
 		got = substitute(want);	
 	} else {
 		is_expression           = 1;
@@ -1711,6 +1747,8 @@ done:
 	if (gotP) {
 		*gotP = got;
 	}
+
+	log_return();
 	return g_buffer.m_P;
 }
 
@@ -1730,7 +1768,9 @@ fixBracedString(const char *startP, fix_typeE want, fix_typeE *gotP)
 	char	**arrayPP;
 	int		c, in_quotes, state;
 	char	*resultP;
-	
+
+	log_enter("fixBracedString (startP=%s, want=%d)", startP, want);
+
 	if (want == FIX_EXPRESSION) {
 		goto dont_fire;
 	}
@@ -1823,6 +1863,7 @@ fire:
 		}
 		xfree(arrayPP);
 		if (resultP) {
+		    log_return_msg("\'fire\' section");
 			return resultP;
 	}	}
 dont_fire:
@@ -1830,6 +1871,8 @@ dont_fire:
 
 	string_to_buffer(startP);
 	resultP = fix_string1(want, gotP);
+
+	log_return_msg("\'dont fire\' section");
 	return resultP;
 }
 
@@ -1849,7 +1892,7 @@ fix_string(const char *stringP, fix_typeE want, fix_typeE *gotP)
 	save             = g_translate_html;
 #endif
 	g_translate_html        = 0;
-    g_underDollarExpression = 0;
+	g_underDollarExpression = 0;
 
 	P = fixBracedString(stringP, want, gotP);
 

--- a/bash-4.3.30/fix_string.h
+++ b/bash-4.3.30/fix_string.h
@@ -1,8 +1,3 @@
-#ifndef TRUE
-#  define TRUE 1
-#  define FALSE 0
-#endif
-
 /* We handle 5 types of data:
 	NONE, INT, STRING, VAR, ARRAY
  */

--- a/tests/v4_tests/baselines/nested_fns.sh.py
+++ b/tests/v4_tests/baselines/nested_fns.sh.py
@@ -1,0 +1,39 @@
+#! /usr/bin/env python
+from __future__ import print_function
+class Bash2Py(object):
+  __slots__ = ["val"]
+  def __init__(self, value=''):
+    self.val = value
+  def setValue(self, value=None):
+    self.val = value
+    return value
+
+def GetVariable(name, local=locals()):
+  if name in local:
+    return local[name]
+  if name in globals():
+    return globals()[name]
+  return None
+
+def Make(name, local=locals()):
+  ret = GetVariable(name, local)
+  if ret is None:
+    ret = Bash2Py(0)
+    globals()[name] = ret
+  return ret
+
+    Make("y").setValue("yyyyy")
+    print("in f2, y is",y.val)
+) :
+    Make("x").setValue("xxxxx")
+    print("in f1, x is",x.val)
+    def f2 () :
+        global x
+        global y
+    
+        Make("y").setValue("yyyyy")
+        print("in f2, y is",y.val)
+    
+    f2()
+
+f1()

--- a/tests/v4_tests/nested_fns.sh
+++ b/tests/v4_tests/nested_fns.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+f1()
+{
+    x=xxxxx
+    echo in f1, x is $x
+
+    f2()
+    {
+        y=yyyyy
+        echo in f2, y is $y
+
+        f3()
+        {
+            z=zzzzz
+            echo in f3, z is $z
+        }
+
+        f3
+    }
+
+    f2
+}
+
+f1
+


### PR DESCRIPTION
Resolves #36. Couldn't help but include some code cleanup as well, mostly with memory (de-)allocation and the `burp*` functions.