### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        cd bash-4.3.30
+        ./configure
+        make lint
+
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: configure and make
+      run: |
+        cd bash-4.3.30
+        bash -c "./configure CFLAGS=-Wno-implicit-function-declaration"
+        bash -c "make bash2pyengine"
+
+    - name: run-all
+      run: |
+        cd tests/bash_tests
+        bash -c "sh ./run-all"

--- a/bash-4.3.30/burp.c
+++ b/bash-4.3.30/burp.c
@@ -323,7 +323,7 @@ char *_build_log_entry(char *format, va_list *pArgs)
 	static char result[128];
 	char fmt_piece[128];
 	void *junk;
-	va_list args = *pArgs;
+	va_list args;
 	int length;
 
 	// Convert format string and arguments
@@ -338,6 +338,7 @@ char *_build_log_entry(char *format, va_list *pArgs)
 		return format;
 	}
 
+	va_copy(args, *pArgs);
 	while (TRUE)
 	{
 		char *pType;
@@ -380,6 +381,7 @@ char *_build_log_entry(char *format, va_list *pArgs)
 			break;
 		}
 	}
+	va_end(args);
 	return result;
 }
 


### PR DESCRIPTION
This PR lints then builds the project and runs `run-all` under Ubuntu and macOS (x86-64) using [GitHub Actions](https://docs.github.com/en/actions) for each pull request and commit to master. You might need to enable GitHub Actions in the [repo settings](https://github.com/clarity20/bash2py/settings), I'm not sure. [As you can see](https://github.com/verhovsky/bash2py-upstream/actions/runs/7355937631/job/20025294801), I was able to get it to compile and run the tests successfully on Ubuntu and macOS (macOS split into separate PR #51) but it's failing to compile on Windows with

```
config.status: executing default commands
yacc -d ./parse.y
process_begin: CreateProcess(NULL, yacc -d ./parse.y, ...) failed.
make (e=2): The system cannot find the file specified.

make: *** [Makefile:624: y.tab.c] Error 2
```

I don't care about Windows so I just removed it, but it would be good to figure out the issue and re-enable it as well.