### PR TITLE
Implement processing of multiple files

### DIFF
--- a/bash-4.3.30/burp.c
+++ b/bash-4.3.30/burp.c
@@ -477,28 +477,31 @@ void log_info(char *format, ...)
 	va_list args;
 	char log_entry[256];
 	char *log_text;
+
 	if (!g_log_stream)
 		return;
 
 	if (!g_log_is_on)
 		return;
 
-	// For "informational" comments use a small indent
-	// so as not to obscure the call stack indicators
-	g_log_indent += SMALL_INDENT;
-
 	va_start(args, format);
 	log_text = _build_log_entry(format, &args);
 	va_end(args);
 
-	// No internal bookkeeping to do as the internals are transient.
-	// Just print, rendering the left-indentation carefully.
-	sprintf(log_entry, "%-*.0d%s(): %s", g_log_indent, 0, *g_current_function, log_text);
-	for (int i=FULL_INDENT-1; i<g_log_indent; i+=FULL_INDENT)
-		log_entry[i]='|';
-	g_log_indent -= SMALL_INDENT;
+	// Print the log line, rendering the left-indentation carefully.
+	if (g_log_indent >= 0)
+	{
+		g_log_indent += SMALL_INDENT;
 
-	fprintf(g_log_stream, "%s", log_entry);
+		sprintf(log_entry, "%-*.0d%s(): %s", g_log_indent, 0, *g_current_function, log_text);
+		for (int i=FULL_INDENT-1; i<g_log_indent; i+=FULL_INDENT)
+			log_entry[i]='|';
+		fprintf(g_log_stream, "%s", log_entry);
+
+		g_log_indent -= SMALL_INDENT;
+	}
+	else
+		fprintf(g_log_stream, "%s", log_text);
 }
 
 // log_return: Simple logging and bookkeeping for function returns

--- a/bash-4.3.30/burp.h
+++ b/bash-4.3.30/burp.h
@@ -21,6 +21,10 @@ typedef struct {
 	int		m_ungetc;
 } burpT;
 
+extern burpT g_buffer;
+extern burpT g_new;
+extern burpT g_braced;
+
 #if !HAVE_STPCPY
 char *stpcpy(char *s1, const char *s2);
 #endif

--- a/bash-4.3.30/dynamo.c
+++ b/bash-4.3.30/dynamo.c
@@ -36,9 +36,9 @@ char *strdup(const char *s) {
 }
 #endif
 
-unsigned char g_left_margin = 0, g_return_count = 0, g_if_count = 0, g_asgn_count = 0;
-unsigned char g_lines_in_func = 0, g_conditional_nesting = 0;
-_BOOL g_inside_class = FALSE, g_is_static = FALSE;
+unsigned char g_left_margin, g_return_count, g_if_count, g_asgn_count;
+unsigned char g_lines_in_func, g_conditional_nesting;
+_BOOL g_inside_class, g_is_static;
 char _EXCEPT[] = "Bash2PyException";
 
 char **g_text_expansions = NULL, **g_func_expansions = NULL;
@@ -59,6 +59,13 @@ void _write_line(char *dest, const char *fmt, ...) {
 
 void init_dynamo(void)
 {
+    g_left_margin = 0, g_return_count = 0, g_if_count = 0, g_asgn_count = 0;
+    g_lines_in_func = 0, g_conditional_nesting = 0;
+    g_inside_class = FALSE, g_is_static = FALSE;
+
+    if (g_text_expansions && g_func_expansions)
+        return;
+
     g_text_expansions = (char**) malloc (128 * sizeof(char *));
     memset(g_text_expansions, '\0', 128);
     g_text_expansions['n'] = strdup("name");
@@ -188,12 +195,16 @@ void cleanup_dynamo(void)
 {
     for (int i=0; i<sizeof(g_text_expansions); i++)
         if (g_text_expansions[i])
-            free(g_text_expansions[i]);
-    free(g_text_expansions);
+            { free(g_text_expansions[i]); g_text_expansions[i] = NULL; }
+    free(g_text_expansions); g_text_expansions = NULL;
     for (int i=0; i<sizeof(g_func_expansions); i++)
         if (g_func_expansions[i])
-            free(g_func_expansions[i]);
-    free(g_func_expansions);
+            { free(g_func_expansions[i]); g_func_expansions[i] = NULL; }
+    free(g_func_expansions); g_func_expansions = NULL;
+
+    g_left_margin = 0, g_return_count = 0, g_if_count = 0, g_asgn_count = 0;
+    g_lines_in_func = 0, g_conditional_nesting = 0;
+    g_inside_class = FALSE, g_is_static = FALSE;
 }
 
 char *_static() {

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -9,14 +9,11 @@
 #include "burp.h"
 #include "fix_string.h"
 
-translateT	g_translate = {0,{0,0,0,0,0,0,0,0,0},
-                            {0,0,0,0,0,0,0,0},
-                            {0,0,0,0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0},
-                            {0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0}};
+translateT	g_translate;
 
-static burpT g_buffer = {0,0,0,0,0,0};
-static burpT g_new = {0,0,0,0,0,0};
-static burpT g_braced = {0,0,0,0,0,0};
+burpT g_buffer = {0,0,0,0,0,0};
+burpT g_new = {0,0,0,0,0,0};
+burpT g_braced = {0,0,0,0,0,0};   // Only directly used in FixBraced()
 
 _BOOL g_regmatch_special_case = FALSE;
 _BOOL g_is_inside_function = FALSE;

--- a/bash-4.3.30/shell.c
+++ b/bash-4.3.30/shell.c
@@ -376,7 +376,7 @@ main (argc, argv, env)
   char **env;
 #endif /* __OPENNT */
 #ifdef BASH2PY
-  char shell_scriptP[128];
+  char input_filename[128];
   int scriptCount = 0;
 
   if (argc < 2)
@@ -775,16 +775,18 @@ main (argc, argv, env)
 #ifdef BASH2PY
   for (int script=1; script<argc; script++)
   {
-    strcpy(shell_scriptP,argv[script]);
-    if (shell_scriptP[0] == '-')
+    char *p, output_filename[32];
+    strcpy(input_filename,argv[script]);
+    if (input_filename[0] == '-')
         continue;
     scriptCount++;
-    initialize_translator(shell_scriptP);
+    p = initialize_translator(input_filename);
+    strcpy(output_filename, p);
 #endif
   reader_loop ();
 #ifdef BASH2PY
     unset_bash_input(0);
-    close_translator();
+    close_translator(output_filename);
     if (script < argc-1)
     {
       fprintf(stdout, "\n");

--- a/bash-4.3.30/shell.c
+++ b/bash-4.3.30/shell.c
@@ -780,8 +780,7 @@ main (argc, argv, env)
     if (input_filename[0] == '-')
         continue;
     scriptCount++;
-    p = initialize_translator(input_filename);
-    strcpy(output_filename, p);
+    strcpy(output_filename, initialize_translator(input_filename));
 #endif
   reader_loop ();
 #ifdef BASH2PY

--- a/bash-4.3.30/shell.h
+++ b/bash-4.3.30/shell.h
@@ -189,6 +189,6 @@ extern sh_input_line_state_t *save_input_line_state __P((sh_input_line_state_t *
 extern void restore_input_line_state __P((sh_input_line_state_t *));
 
 #ifdef BASH2PY
-extern void initialize_translator(const char *);
+extern char *initialize_translator(const char *);
 extern void close_translator(const char *);
 #endif

--- a/bash-4.3.30/shell.h
+++ b/bash-4.3.30/shell.h
@@ -189,6 +189,6 @@ extern sh_input_line_state_t *save_input_line_state __P((sh_input_line_state_t *
 extern void restore_input_line_state __P((sh_input_line_state_t *));
 
 #ifdef BASH2PY
-extern void initialize_translator();
-extern void close_translator();
+extern void initialize_translator(const char *);
+extern void close_translator(const char *);
 #endif

--- a/bash-4.3.30/shell.h
+++ b/bash-4.3.30/shell.h
@@ -187,3 +187,8 @@ extern void restore_parser_state __P((sh_parser_state_t *));
 
 extern sh_input_line_state_t *save_input_line_state __P((sh_input_line_state_t *));
 extern void restore_input_line_state __P((sh_input_line_state_t *));
+
+#ifdef BASH2PY
+extern void initialize_translator();
+extern void close_translator();
+#endif

--- a/bash-4.3.30/translate.c
+++ b/bash-4.3.30/translate.c
@@ -3061,32 +3061,33 @@ void seen_comment_char(int c)
 	}
 }
 
-char *initialize_translator(const char *shell_scriptP)
+char *initialize_translator(const char *input_filename)
 {
-    static char output_fname[32];
-    char file_suffix[6];
+    static char output_filename[32];
 
 	log_init();
     log_activate();
     init_dynamo();
 
-    strcpy(file_suffix, g_translate_html ? "html" : "py");
-
-	if (!shell_scriptP) {
-	  sprintf(output_fname, "output.%s", file_suffix);
-	  outputF = fopen(output_fname, "w");
+	if (!input_filename) {
+	  strcpy(output_filename, "output.py");
+	  outputF = fopen(output_filename, "w");
 	  if (!outputF) {
-		fprintf(stderr, "Can't open default output file %s\n", output_fname);
+		fprintf(stderr, "Can't open default output file %s\n", output_filename);
 		exit(1);
 	  }
 	} else {
 	  char *extensionP;
 
-	  extensionP = strrchr(shell_scriptP, '.');
-	  sprintf(output_fname, "%s.%s", shell_scriptP, file_suffix);
-	  outputF = fopen(output_fname, "w");
+	  strcpy(output_filename, input_filename);
+	  if (extensionP = strrchr(output_filename, '.'))
+		strcpy(extensionP, ".py");
+	  else
+		strcat(output_filename, ".py");
+
+	  outputF = fopen(output_filename, "w");
 	  if (!outputF) {
-		fprintf(stderr, "Can't open output file %s\n", output_fname);
+		fprintf(stderr, "Can't open output file %s\n", output_filename);
 		exit(1);
 	  }
 	}
@@ -3106,7 +3107,7 @@ char *initialize_translator(const char *shell_scriptP)
     memset(&g_new, 0, sizeof(g_new));
     memset(&g_braced, 0, sizeof(g_braced));
 
-    return output_fname;
+    return output_filename;
 }
 
 void print_translation(COMMAND * command)

--- a/bash-4.3.30/translate.c
+++ b/bash-4.3.30/translate.c
@@ -96,6 +96,7 @@ burpT	g_output  = {0, 0, 0, 0, 0, 0};
 
 static burpT	g_commentBuffer = {0, 0, 0, 0, 0, 0};
 static burpT	g_temp    = {0, 0, 0, 0, 0, 0};
+static burpT	save = {0,0,0,0,0,0};
 
 typedef struct function_nameS {
 	struct function_nameS *m_nextP;
@@ -1525,8 +1526,8 @@ static void print_echo_command(WORD_LIST *word_listP, REDIRECT *redirects)
 	if (quoted_word_count > 0) {
 		burp(&g_output, "\"%s\"", quoted_word_buffer.m_P);
 		quoted_word_count = 0;
-		burp_reset(&quoted_word_buffer);
 	}
+	burp_close(&quoted_word_buffer);
 
 	if (n_flag) {
 		/* Only works with python 3 */
@@ -2675,8 +2676,6 @@ static void reset_locals ()
 
 static void print_function_def (FUNCTION_DEF *func)
 {
-	static burpT	save = {0,0,0,0,0,0};
-	
 	burpT	temp;
 	COMMAND *cmdcopy;
 	REDIRECT *func_redirects;
@@ -3101,6 +3100,13 @@ char *initialize_translator(const char *shell_scriptP)
 		fprintf(outputF, "</td></tr>\n");
 	}
 
+	// Initialize the translation state object and buffer objects
+    memset(&g_translate, 0, sizeof(g_translate));
+    memset(&g_buffer, 0, sizeof(g_buffer));
+    memset(&g_new, 0, sizeof(g_new));
+    memset(&g_braced, 0, sizeof(g_braced));
+
+    return output_fname;
 }
 
 void print_translation(COMMAND * command)
@@ -3641,6 +3647,17 @@ void close_translator(const char *output_fname)
 		fprintf(outputF, "</body>\n</html>\n");
 	}
 	fclose(outputF);
+    outputF = NULL;
+
+    burp_close(&g_case_var);
+    burp_close(&g_output);
+    burp_close(&g_commentBuffer);
+    burp_close(&g_temp);
+    burp_close(&save);
+
+    burp_close(&g_buffer);
+    burp_close(&g_new);
+    burp_close(&g_braced);
 
 	dispose_all_function_names();
     cleanup_dynamo();

--- a/bash-4.3.30/translate.h
+++ b/bash-4.3.30/translate.h
@@ -15,7 +15,7 @@
 extern FILE *outputF;
 
 void print_translation(COMMAND* command);
-void initialize_translator();
-void close_translator();
+char *initialize_translator(const char *filename);
+void close_translator(const char *filename);
 
 #endif //__TRANSLATE_H__


### PR DESCRIPTION
With this enhancement the executable can take a sequence of input files and the output files will be named accordingly, e.g. `bash2pyengine foo.sh bar.sh` produces `foo.py` and `bar.py`. The logging announces the names of the output files as they are created.