### PR TITLE
Re-enable test run of regex.sh

### DIFF
--- a/bash-4.3.30/burp.c
+++ b/bash-4.3.30/burp.c
@@ -205,6 +205,7 @@ void burp(burpT *burpP, const char *fmtP, ...)
 
     burps(burpP, buf);
  	free(buf);
+ 	buf = NULL;
 
  	return;
 }
@@ -294,6 +295,7 @@ void log_close()
 	{
 		fprintf(g_log_stream, "WARNING: Logger has no record of a proper return from function %s,\n", *g_current_function);
 		free(*g_current_function);
+		*g_current_function = NULL;
 		g_current_function--;
 	}
 	free(g_function_stack);
@@ -358,7 +360,7 @@ char *type_to_text(fix_typeE value)
 // We leave it up to the caller to left-pad to show the function stack depth.
 char *_build_log_entry(char *format, va_list *pArgs)
 {
-	static char result[128];
+	static char result[192];
 	char fmt_piece[128];
 	void *junk;
 	va_list args;
@@ -556,6 +558,7 @@ void log_return_msg(char *msg_template, ...)
 
 	// Internal log bookkeeping
 	free(*g_current_function);
+	*g_current_function = NULL;
 	g_current_function--;
 	g_log_indent -= FULL_INDENT;
 }

--- a/bash-4.3.30/fix_string.c
+++ b/bash-4.3.30/fix_string.c
@@ -1285,6 +1285,7 @@ static fix_typeE substitute(fix_typeE want)
 	case FIX_VAR:
 		if (P = isInteger(g_buffer.m_P)) {
 			burps(&g_new, P);
+			log_return_msg("%s = simple integer, nothing to substitute", P);
 			return FIX_INT;
 		}
 	}
@@ -1820,7 +1821,9 @@ expand_brace_expr:
 	
 			for (i = 0; P = arrayPP[i]; ) {
 				string_to_buffer(arrayPP[i]);
+log_activate();
 				P = fix_string1(single_want_type, gotP);
+log_deactivate();
 				burps(&g_braced, P);
 				++i;
 				if (arrayPP[i]) {

--- a/bash-4.3.30/translate.c
+++ b/bash-4.3.30/translate.c
@@ -1392,14 +1392,14 @@ static _BOOL isAssignment(char *startP, _BOOL local)
 			c = *++P;
 	}	}
 
-	// Assignment operator can be  +=,  -=,  or  = //TODO MMMM The point here is to distinguish end of identifier from location of = sign
+	// Assignment operator can be  +=,  -=,  or  = 
+	// N.B. We need to distinguish end of identifier from location of = sign
 	switch (c) {
 	case '+':
 	case '-':
 		++P;
 	}
 	if (*P == '=') {
-//TODO: Move print_assignment() out to the caller(s)
 		print_assignment_command(startP, after_nameP, end_arrayP, P, local);
 		log_return_msg("%q IS an assignment.", startP);
 		return TRUE;

--- a/tests/v4_tests/regex.sh
+++ b/tests/v4_tests/regex.sh
@@ -6,15 +6,18 @@ fi
 
 if [[ "$1" =~ r(.) ]]; then
     echo "$1" contains r plus ${BASH_REMATCH[1]}.
+    br0=${BASH_REMATCH[0]}
 fi
 
 if [[ "$1" =~ x ]]; then
+    br0=${BASH_REMATCH[0]}
     echo "$1" contains x.
 elif [[ "$1" =~ w ]]; then
+    br0=${BASH_REMATCH[0]}
     echo "$1" contains w.
 fi
 
-echo To reiterate '(x>w>r.)', "$1" contains ${BASH_REMATCH[0]}.
+echo To reiterate '(x>w>r.)', "$1" contains $br0.
 
 [[ "$1" =~ r(.) ]]
 echo Successor of \'r\' in "$1" is ${BASH_REMATCH[1]}.


### PR DESCRIPTION
Increase static buffer for logging
Add a log_return to substitute() for balance
Edit regex.sh for proper testing
Zero-out freed logging buffers

The main achievement here is to enable test running regex.sh, which was crashing per #61.